### PR TITLE
readme: replace reference to --cloth-input-file with --input-dir and quote shell variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To generate network topologies, follow these steps:
     * `--end`: simulation end time (default 100000.00)
 
     Additionally, the model accepts these input parameters:
-    * `--cloth-input-file`: path to the CLoTH input file
+    * `--input-dir`: directory containing the files defining the simulation parameters. The simulation parameters are read from the following files: `plasma_network_channels.csv`, `plasma_network_edges.csv`, `plasma_network_nodes.csv`, `plasma_paths.csv`, which can be generated as described above
     * `--output-dir`: output directory where simulation results are stored (must exist)
     * `--tps`: constant load mode (transactions per second)
     * `--tps-config`: variable load mode (configured by a file)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To generate network topologies, follow these steps:
     mkdir -p experiments/workspace/results
 
     OUTDIR="experiments/workspace/results/$(date +"%Y%m%d%H%M%S")"
-    mkdir -p $OUTDIR
+    mkdir -p "${OUTDIR}"
 
     NP=4 && \
     INDIR="experiments/workspace/topologies/seed_42/capacity-0.5/k_0${NP}" && \
@@ -103,15 +103,15 @@ To generate network topologies, follow these steps:
 
 ## Analyze results
 
-1. You can calculate statistical about simulation results using the statistics analyzer utility. For example, after executing the following command, you will find the aggregated results in cloth_output.json
+1. You can calculate statistical about simulation results using the statistics analyzer utility. For example, after executing the following command, you will find the aggregated results in `cloth_output.json`
 
     ```bash
     cd ~/itcoin-pcn-simulator/utilities
-    OUTDIR=$OUTDIR poetry shell
+    OUTDIR="${OUTDIR}" poetry shell
 
     python statistics_analyzer/commands/analyzer.py \
-        --input-dir ../$OUTDIR \
-        --output-dir ../$OUTDIR
+        --input-dir ../"${OUTDIR}" \
+        --output-dir ../"${OUTDIR}"
     ```
 
 ## More advances examples


### PR DESCRIPTION
* `--cloth-input-file` is a renmant from a preliminary version of this work.
   The parameter controlling the simulation parameters is `--input-dir` and defines a directory name with a specific requirement on its contents (`plasma_network_channels.csv`, `plasma_network_edges.csv`, `plasma_network_nodes.csv`, `plasma_paths.csv`)
* quoted variables in the shell examples in the README (we can't assume someone clones the project in a base directory containing spaces :smile:)
