### PR TITLE
Plasma network generator: stop generating cloth_input.txt, fix two oversights

### DIFF
--- a/utilities/plasma_network_generator/cloth_dump.py
+++ b/utilities/plasma_network_generator/cloth_dump.py
@@ -209,7 +209,7 @@ def cloth_output(
                         )
 
 
-def plasma_network_generator_cloth_dumb_main(argv) -> int:
+def plasma_network_generator_cloth_dump_main(argv) -> int:
     cmdline_flags = parse_commandline_args(argv)
     configure_logging(True)
     output_dir = pathlib.Path(cmdline_flags["output_dir"]).resolve()
@@ -233,4 +233,4 @@ def plasma_network_generator_cloth_dumb_main(argv) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(plasma_network_generator_cloth_dumb_main(sys.argv))
+    sys.exit(plasma_network_generator_cloth_dump_main(sys.argv))

--- a/utilities/plasma_network_generator/cloth_dump.py
+++ b/utilities/plasma_network_generator/cloth_dump.py
@@ -4,7 +4,6 @@ import json
 import logging
 import pathlib
 import sys
-from textwrap import dedent
 
 import matplotlib as mpl
 import matplotlib.colors as mcolors
@@ -208,19 +207,6 @@ def cloth_output(
                             plasma_network.nodes[i1]["label"],
                             plasma_network.nodes[i2]["label"],
                         )
-
-    # save the cloth_input.txt file
-    with (output_dir / "cloth_input.txt").open(mode="w") as cloth_input_file:
-        cloth_input_file.write(
-            dedent(
-                f"""\
-            nodes_filename={output_dir / "plasma_network_nodes.csv"}
-            channels_filename={output_dir / "plasma_network_channels.csv"}
-            edges_filename={output_dir / "plasma_network_edges.csv"}
-            paths_filename={output_dir / "plasma_paths.csv"}
-            """,
-            ),
-        )
 
 
 def plasma_network_generator_cloth_dumb_main(argv) -> int:

--- a/utilities/plasma_network_generator/commands/generate_all.py
+++ b/utilities/plasma_network_generator/commands/generate_all.py
@@ -20,7 +20,7 @@ import networkx as nx
 
 from plasma_network_generator.cloth_dump import (
     cloth_output,
-    plasma_network_generator_cloth_dumb_main,
+    plasma_network_generator_cloth_dump_main,
 )
 from plasma_network_generator.commands.networkx_generator import (
     DEFAULT_NATIONS,
@@ -234,7 +234,7 @@ def parse_args() -> Args:
 
 def call_cloth_dump(input_file: Path, output_dir: Path, n_partitions: int) -> None:
     """Call the cloth dump."""
-    plasma_network_generator_cloth_dumb_main(
+    plasma_network_generator_cloth_dump_main(
         [
             "cloth_dump.py",
             "-input",

--- a/utilities/statistics_analyzer/commands/analyzer.py
+++ b/utilities/statistics_analyzer/commands/analyzer.py
@@ -538,6 +538,7 @@ def _do_job(args: Args, pattern: str) -> None:
         | payments_stats.stats_per_minute
     )
     output_file.write_text(json.dumps(output_data, indent=4))
+    logging.info("Results written in %s", output_file)
 
 
 def _execute(args: Args) -> None:


### PR DESCRIPTION
1. in a preliminary version of this work we used the file `cloth_input.txt` to list the paths to `plasma_network_channels.csv`, `plasma_network_edges.csv`, `plasma_network_nodes.csv`, `plasma_paths.csv`.
   In the final version of the project we stopped relying on `cloth_input.txt`: we simply take as input a directory name and read the relevant input files from there. There is no need to continue generating `cloth_input.txt`
2. add a log message specifying where `statistics_analyzer/commands/analyzer.py` generates its output file
   ```
   [2024-09-18 09:16:21,527][INFO][analyzer.py:561] CLoTH Statistics Analyzer running at <BASE>/experiments/workspace/results/20240918091214
   [2024-09-18 09:16:29,937][INFO][analyzer.py:541] Results written in <BASE>/experiments/workspace/results/20240918091214/cloth_output.json
   ```
3. remove an oversight in a function name: "cloth_dumb_main" -> "cloth_dump_main"