### PR TITLE
build: use absolute paths in Makefile

### DIFF
--- a/utilities/Makefile
+++ b/utilities/Makefile
@@ -16,11 +16,11 @@ export PRINT_HELP_PYSCRIPT
 
 .PHONY: black
 black: ## apply black formatting
-	black .
+	black $(MAKEFILE_ABS_DIR)
 
 .PHONY: black-check
 black-check: ## check black formatting
-	black --check .
+	black --check $(MAKEFILE_ABS_DIR)
 
 .PHONY: help
 help:
@@ -34,12 +34,12 @@ lint-check: ruff-check black-check ## check linting and black formatting
 
 .PHONY: mypy
 mypy: ## static check with mypy
-	mypy .
+	mypy $(MAKEFILE_ABS_DIR)
 
 .PHONY: ruff
 ruff: ## run ruff linter on the project. Act on fixable issues
-	ruff check --fix .
+	ruff check --fix $(MAKEFILE_ABS_DIR)
 
 .PHONY: ruff-check
 ruff-check: ## run ruff linter on the project, do not change files
-	ruff check .
+	ruff check $(MAKEFILE_ABS_DIR)


### PR DESCRIPTION
Before this change, the `Makefile` implicitly assumed that it was being called with cwd == dir(Makefile), for example the following commands would give the wrong result:

```
cd src
make -f ../utilities/Makefile black-check
black --check .
No Python files are present to be formatted. Nothing to do 😴
```

This solution is still vulnerable to path names needing quoting (e.g.: spaces, evil characters), but it's a first step.