### PR TITLE
simulator: untangle includes

### DIFF
--- a/src/features/htlc.c
+++ b/src/features/htlc.c
@@ -14,6 +14,7 @@
 #include "../model/pcn_node.h"
 #include "../model/global.h"
 
+#include "../utils/array.h"
 #include "../utils/list.h"
 #include "../utils/logging.h"
 #include "../utils/utils.h"

--- a/src/features/htlc.c
+++ b/src/features/htlc.c
@@ -286,7 +286,7 @@ int send_payment(tw_lp *lp, struct payment* payment) {
     payment->error.hop = first_route_hop;
     // Generate RECEIVEFAIL
     tw_event *receive_fail_e = tw_event_new(lp->gid, OFFLINELATENCY, lp);
-    message *receive_fail_msg = tw_event_data(receive_fail_e);
+    struct message *receive_fail_msg = tw_event_data(receive_fail_e);
     receive_fail_msg->type = RECEIVEFAIL;
     serialize_payment(payment, receive_fail_msg->data);
     tw_event_send(receive_fail_e);
@@ -300,7 +300,7 @@ int send_payment(tw_lp *lp, struct payment* payment) {
     payment->no_balance_count += 1;
     // Generate RECEIVEFAIL
     tw_event* next_e = tw_event_new(lp->gid, 10, lp);
-    message* next_msg = tw_event_data(next_e);
+    struct message* next_msg = tw_event_data(next_e);
     next_msg->type = RECEIVEFAIL;
     serialize_payment(payment, next_msg->data);
     tw_event_send(next_e);
@@ -314,7 +314,7 @@ int send_payment(tw_lp *lp, struct payment* payment) {
   // Generate RECEIVEPAYMENT or FORWARDPAYMENT
   unsigned int rng_calls = 0;
   tw_event *next_e = tw_event_new(first_route_hop->to_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = first_route_hop->to_node_id == payment->receiver ? RECEIVEPAYMENT : FORWARDPAYMENT;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -352,7 +352,7 @@ int forward_payment(tw_lp *lp, struct payment* payment) {
     int prev_node_id = previous_route_hop->from_node_id;
     // Generate RECEIVEFAIL or FORWARDFAIL
     tw_event *receive_fail_e = tw_event_new(prev_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA) + OFFLINELATENCY, lp);
-    message *receive_fail_msg = tw_event_data(receive_fail_e);
+    struct message *receive_fail_msg = tw_event_data(receive_fail_e);
     receive_fail_msg->type = prev_node_id == payment->sender ? RECEIVEFAIL : FORWARDFAIL;
     serialize_payment(payment, receive_fail_msg->data);
     tw_event_send(receive_fail_e);
@@ -377,7 +377,7 @@ int forward_payment(tw_lp *lp, struct payment* payment) {
     if (payment->error.type == NOERROR){
       payment->error.type = NOBALANCE;
       tw_event* notify_evt = tw_event_new(payment->receiver, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-      message* notify_msg = tw_event_data(notify_evt);
+      struct message* notify_msg = tw_event_data(notify_evt);
       notify_msg->type = NOTIFYPAYMENT;
       serialize_payment(payment, notify_msg->data);
       tw_event_send(notify_evt);
@@ -385,7 +385,7 @@ int forward_payment(tw_lp *lp, struct payment* payment) {
 
     // Retry to forward in a few sec
     tw_event *next_e = tw_event_new(node->id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-    message *next_msg = tw_event_data(next_e);
+    struct message *next_msg = tw_event_data(next_e);
     next_msg->type = FORWARDPAYMENT;
     serialize_payment(payment, next_msg->data);
     tw_event_send(next_e);
@@ -399,7 +399,7 @@ int forward_payment(tw_lp *lp, struct payment* payment) {
     long prev_node_id = previous_route_hop->from_node_id;
     // Generate RECEIVEFAIL or FORWARDFAIL
     tw_event *next_e = tw_event_new(prev_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-    message *next_msg = tw_event_data(next_e);
+    struct message *next_msg = tw_event_data(next_e);
     next_msg->type = prev_node_id == payment->sender ? RECEIVEFAIL : FORWARDFAIL;
     serialize_payment(payment, next_msg->data);
     tw_event_send(next_e);
@@ -412,7 +412,7 @@ int forward_payment(tw_lp *lp, struct payment* payment) {
 
   // Generate RECEIVEPAYMENT or FORWARDPAYMENT
   tw_event *next_e = tw_event_new(next_route_hop->to_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = next_route_hop->to_node_id == payment->receiver ? RECEIVEPAYMENT : FORWARDPAYMENT;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -446,7 +446,7 @@ void receive_payment(tw_lp *lp, struct payment* payment){
   // Generate RECEIVESUCCESS or FORWARDSUCCESS
   unsigned int rng_calls = 0;
   tw_event *next_e = tw_event_new(prev_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = prev_node_id == payment->sender ? RECEIVESUCCESS : FORWARDSUCCESS;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -460,7 +460,7 @@ void receive_payment(tw_lp *lp, struct payment* payment){
     if(node->rw_awaiting_payment != NULL && node->rw_withdrawal_id == payment->id){
       // The awaiting payment has been found, create the FINDPATH
       tw_event *find_path_e = tw_event_new(node->rw_awaiting_payment->sender, 10, lp);
-      message *find_path_msg = tw_event_data(find_path_e);
+      struct message *find_path_msg = tw_event_data(find_path_e);
       find_path_msg->type = FINDPATH;
       serialize_payment(node->rw_awaiting_payment, find_path_msg->data);
       tw_event_send(find_path_e);
@@ -490,7 +490,7 @@ void forward_success(tw_lp *lp, struct payment* payment) {
   // Generate RECEIVESUCCESS or FORWARDSUCCESS
   unsigned int rng_calls = 0;
   tw_event *next_e = tw_event_new(prev_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = prev_node_id == payment->sender ? RECEIVESUCCESS : FORWARDSUCCESS;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -525,7 +525,7 @@ void forward_fail(tw_lp *lp, struct payment* payment) {
   // Generate RECEIVEFAIL or FORWARDFAIL
   unsigned int rng_calls = 0;
   tw_event *next_e = tw_event_new(prev_node_id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = prev_node_id == payment->sender ? RECEIVEFAIL : FORWARDFAIL;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -551,7 +551,7 @@ void receive_fail(tw_lp *lp, struct payment* payment) {
 
   // Generate FINDPATH
   tw_event *next_e = tw_event_new(payment->sender, 10, lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = FINDPATH;
   serialize_payment(payment, next_msg->data);
   tw_event_send(next_e);
@@ -579,7 +579,7 @@ void notify_payment(tw_lp *lp, struct payment* payment) {
   // Forward the FINDPATH event
   // Here we would like to simulate a RTT between the user and its custodian, to ask and receive for a deposit invoice (200 + 2*RAND), plus the time to create the findpath event (10)
   tw_event *next_e = tw_event_new(deposit_to_forward->sender, 10 + 2*tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = FINDPATH;
   serialize_payment(deposit_to_forward, next_msg->data);
   tw_event_send(next_e);

--- a/src/features/htlc.c
+++ b/src/features/htlc.c
@@ -265,7 +265,7 @@ struct array * find_path(router_state *router_state, struct payment *payment, ui
 }
 
 /* send an HTLC for the payment (behavior of the payment sender) */
-int send_payment(tw_lp *lp, payment* payment) {
+int send_payment(tw_lp *lp, struct payment* payment) {
   // Get the node
   struct node* node = lp->cur_state;
 
@@ -322,7 +322,7 @@ int send_payment(tw_lp *lp, payment* payment) {
 }
 
 /* forward an HTLC for the payment (behavior of an intermediate hop node in a route) */
-int forward_payment(tw_lp *lp, payment* payment) {
+int forward_payment(tw_lp *lp, struct payment* payment) {
   struct node *node = lp->cur_state;
 
   struct route* route = payment->route;
@@ -420,7 +420,7 @@ int forward_payment(tw_lp *lp, payment* payment) {
 }
 
 /* receive a payment (behavior of the payment receiver node) */
-void receive_payment(tw_lp *lp, payment* payment){
+void receive_payment(tw_lp *lp, struct payment* payment){
   long  prev_node_id;
   struct route* route;
   struct route_hop* last_route_hop;
@@ -469,7 +469,7 @@ void receive_payment(tw_lp *lp, payment* payment){
 }
 
 /* forward an HTLC success back to the payment sender (behavior of a intermediate hop node in the route) */
-void forward_success(tw_lp *lp, payment* payment) {
+void forward_success(tw_lp *lp, struct payment* payment) {
   struct route_hop* prev_hop;
   struct edge* forward_edge, * backward_edge;
   long prev_node_id;
@@ -497,12 +497,12 @@ void forward_success(tw_lp *lp, payment* payment) {
 }
 
 /* receive an HTLC success (behavior of the payment sender node) */
-void receive_success(tw_lp *lp, payment* payment){
+void receive_success(tw_lp *lp, struct payment* payment){
   payment->end_time = tw_now(lp);
 }
 
 /* forward an HTLC fail back to the payment sender (behavior of a intermediate hop node in the route) */
-void forward_fail(tw_lp *lp, payment* payment) {
+void forward_fail(tw_lp *lp, struct payment* payment) {
   struct route_hop* next_hop, *prev_hop;
   struct edge* next_edge;
   long prev_node_id;
@@ -532,7 +532,7 @@ void forward_fail(tw_lp *lp, payment* payment) {
 }
 
 /* receive an HTLC fail (behavior of the payment sender node) */
-void receive_fail(tw_lp *lp, payment* payment) {
+void receive_fail(tw_lp *lp, struct payment* payment) {
   struct route_hop* first_hop, *error_hop;
   struct edge* next_edge;
   struct event* next_event;
@@ -557,7 +557,7 @@ void receive_fail(tw_lp *lp, payment* payment) {
   tw_event_send(next_e);
 }
 
-void notify_payment(tw_lp *lp, payment* payment) {
+void notify_payment(tw_lp *lp, struct payment* payment) {
   struct node* node = lp->cur_state;
   if(node->id != payment->receiver) {
     printf("ERROR (notify_payment): node id %ld and payment receiver %ld are not the same\n", node->id, payment->receiver);
@@ -587,7 +587,7 @@ void notify_payment(tw_lp *lp, payment* payment) {
 }
 
 
-void rev_send_payment(tw_lp *lp, payment* payment) {
+void rev_send_payment(tw_lp *lp, struct payment* payment) {
   struct node* node = lp->cur_state;
   struct route* route = payment->route;
   struct route_hop* first_route_hop = array_get(route->route_hops, 0);
@@ -598,7 +598,7 @@ void rev_send_payment(tw_lp *lp, payment* payment) {
   next_edge->tot_flows -= 1;
 }
 
-void rev_forward_payment(tw_lp *lp, payment* payment) {
+void rev_forward_payment(tw_lp *lp, struct payment* payment) {
   struct route* route = payment->route;
   struct node* node = lp->cur_state;
 
@@ -609,7 +609,7 @@ void rev_forward_payment(tw_lp *lp, payment* payment) {
   next_edge->tot_flows -= 1;
 }
 
-void rev_receive_payment(tw_lp *lp, payment* payment) {
+void rev_receive_payment(tw_lp *lp, struct payment* payment) {
   struct route* route;
   struct route_hop* last_route_hop;
   struct edge* forward_edge, *backward_edge;
@@ -625,7 +625,7 @@ void rev_receive_payment(tw_lp *lp, payment* payment) {
   backward_edge->balance -= last_route_hop->amount_to_forward;
 }
 
-void rev_forward_success(tw_lp *lp, payment* payment) {
+void rev_forward_success(tw_lp *lp, struct payment* payment) {
   struct route_hop* prev_hop;
   struct edge* forward_edge, * backward_edge;
 
@@ -635,10 +635,10 @@ void rev_forward_success(tw_lp *lp, payment* payment) {
 
   backward_edge->balance -= prev_hop->amount_to_forward;
 }
-void rev_receive_success(tw_lp *lp, payment* payment){
+void rev_receive_success(tw_lp *lp, struct payment* payment){
   payment->end_time = 0;
 }
-void rev_forward_fail(tw_lp *lp, payment* payment) {
+void rev_forward_fail(tw_lp *lp, struct payment* payment) {
   struct route_hop* next_hop;
   struct edge* next_edge;
 
@@ -648,7 +648,7 @@ void rev_forward_fail(tw_lp *lp, payment* payment) {
   next_edge->balance -= next_hop->amount_to_forward;
 }
 
-void rev_receive_fail(tw_lp *lp, payment* payment) {
+void rev_receive_fail(tw_lp *lp, struct payment* payment) {
   struct route_hop* first_hop, *error_hop;
   struct edge* next_edge;
 
@@ -660,5 +660,5 @@ void rev_receive_fail(tw_lp *lp, payment* payment) {
   }
 }
 
-void rev_notify_payment(tw_lp *lp, payment* payment) {
+void rev_notify_payment(tw_lp *lp, struct payment* payment) {
 }

--- a/src/features/htlc.c
+++ b/src/features/htlc.c
@@ -11,6 +11,7 @@
 
 #include "../features/payments.h"
 
+#include "../model/message.h"
 #include "../model/pcn_node.h"
 #include "../model/global.h"
 

--- a/src/features/htlc.c
+++ b/src/features/htlc.c
@@ -199,7 +199,7 @@ void process_fail_result(struct node* node, struct payment *payment, uint64_t cu
 /*HTLC FUNCTIONS*/
 
 /* find a path for a payment (a modified version of dijkstra is used: see `routing.c`) */
-struct array * find_path(router_state *router_state, struct payment *payment, uint64_t current_time, struct network* network) {
+struct array * find_path(struct router_state *router_state, struct payment *payment, uint64_t current_time, struct network* network) {
   struct array *path;
   enum pathfind_error error;
   struct node* src, *dest;

--- a/src/features/htlc.h
+++ b/src/features/htlc.h
@@ -5,14 +5,15 @@
 
 #include <ross.h>
 
-#include "routing.h"
-
 #define OFFLINELATENCY 3000 //3 seconds waiting for a node not responding (tcp default retransmission time)
 
 
 struct edge;
+struct network;
+struct node;
 struct payment;
 struct policy;
+struct router_state;
 
 /* a node pair result registers the most recent result of a payment (fail or success, with the corresponding amount and time)
    that occurred when the payment traversed an edge connecting the two nodes of the node pair */

--- a/src/features/htlc.h
+++ b/src/features/htlc.h
@@ -5,13 +5,14 @@
 
 #include <ross.h>
 
-#include "network.h"
 #include "routing.h"
 
 #define OFFLINELATENCY 3000 //3 seconds waiting for a node not responding (tcp default retransmission time)
 
 
+struct edge;
 struct payment;
+struct policy;
 
 /* a node pair result registers the most recent result of a payment (fail or success, with the corresponding amount and time)
    that occurred when the payment traversed an edge connecting the two nodes of the node pair */

--- a/src/features/htlc.h
+++ b/src/features/htlc.h
@@ -27,7 +27,7 @@ struct node_pair_result{
 
 uint64_t compute_fee(uint64_t amount_to_forward, struct policy policy);
 
-struct array * find_path(router_state *router_state, struct payment *payment, uint64_t current_time, struct network* network);
+struct array * find_path(struct router_state *router_state, struct payment *payment, uint64_t current_time, struct network* network);
 
 int send_payment(tw_lp *lp, struct payment* payment);
 

--- a/src/features/htlc.h
+++ b/src/features/htlc.h
@@ -10,6 +10,9 @@
 
 #define OFFLINELATENCY 3000 //3 seconds waiting for a node not responding (tcp default retransmission time)
 
+
+struct payment;
+
 /* a node pair result registers the most recent result of a payment (fail or success, with the corresponding amount and time)
    that occurred when the payment traversed an edge connecting the two nodes of the node pair */
 struct node_pair_result{
@@ -25,19 +28,19 @@ uint64_t compute_fee(uint64_t amount_to_forward, struct policy policy);
 
 struct array * find_path(router_state *router_state, struct payment *payment, uint64_t current_time, struct network* network);
 
-int send_payment(tw_lp *lp, payment* payment);
+int send_payment(tw_lp *lp, struct payment* payment);
 
-int forward_payment(tw_lp *lp, payment* payment);
+int forward_payment(tw_lp *lp, struct payment* payment);
 
-void receive_payment(tw_lp *lp, payment* payment);
+void receive_payment(tw_lp *lp, struct payment* payment);
 
-void forward_success(tw_lp *lp, payment* payment);
+void forward_success(tw_lp *lp, struct payment* payment);
 
-void receive_success(tw_lp *lp, payment* payment);
+void receive_success(tw_lp *lp, struct payment* payment);
 
-void forward_fail(tw_lp *lp, payment* payment);
+void forward_fail(tw_lp *lp, struct payment* payment);
 
-void receive_fail(tw_lp *lp, payment* payment);
+void receive_fail(tw_lp *lp, struct payment* payment);
 
 struct route_hop *get_route_hop(long node_id, struct array *route_hops, int is_sender);
 
@@ -47,15 +50,15 @@ void process_success_result(struct node* node, struct payment *payment, uint64_t
 
 void process_fail_result(struct node* node, struct payment *payment, uint64_t current_time);
 
-void notify_payment(tw_lp *lp, payment* payment);
+void notify_payment(tw_lp *lp, struct payment* payment);
 
-void rev_send_payment(tw_lp *lp, payment* payment);
-void rev_forward_payment(tw_lp *lp, payment* payment);
-void rev_receive_payment(tw_lp *lp, payment* payment);
-void rev_forward_success(tw_lp *lp, payment* payment);
-void rev_receive_success(tw_lp *lp, payment* payment);
-void rev_forward_fail(tw_lp *lp, payment* payment);
-void rev_receive_fail(tw_lp *lp, payment* payment);
-void rev_notify_payment(tw_lp *lp, payment* payment);
+void rev_send_payment(tw_lp *lp, struct payment* payment);
+void rev_forward_payment(tw_lp *lp, struct payment* payment);
+void rev_receive_payment(tw_lp *lp, struct payment* payment);
+void rev_forward_success(tw_lp *lp, struct payment* payment);
+void rev_receive_success(tw_lp *lp, struct payment* payment);
+void rev_forward_fail(tw_lp *lp, struct payment* payment);
+void rev_receive_fail(tw_lp *lp, struct payment* payment);
+void rev_notify_payment(tw_lp *lp, struct payment* payment);
 
 #endif

--- a/src/features/network.h
+++ b/src/features/network.h
@@ -79,7 +79,7 @@ struct node_list_element {
 };
 
 /* a node of the payment-channel network */
-typedef struct node {
+struct node {
   long id;
   char* label;
   long intermediary;
@@ -97,7 +97,7 @@ typedef struct node {
   long rw_withdrawal_id;
   // Pending submarine swaps
   struct array* submarine_swaps;
-} node;
+};
 
 /* a bidirectional payment channel of the payment-channel network open between two nodes */
 typedef struct channel {

--- a/src/features/payments.c
+++ b/src/features/payments.c
@@ -75,7 +75,7 @@ void set_expired_payment(struct payment* payment, uint64_t current_time){
   payment->is_timeout = 1;
 }
 
-void serialize_payment(payment* payment, char* serialized){
+void serialize_payment(struct payment* payment, char* serialized){
     if (!payment || !serialized) {
         return; // Invalid input or insufficient buffer size
     }
@@ -209,9 +209,9 @@ void serialize_payment(payment* payment, char* serialized){
     }
 }
 
-payment* deserialize_payment(const char* serialized){
+struct payment* deserialize_payment(const char* serialized){
 
-    payment* payment;
+    struct payment* payment;
     size_t payment_size = 0;
 
     const char *current_pos = serialized;

--- a/src/features/payments.h
+++ b/src/features/payments.h
@@ -24,7 +24,7 @@ struct payment_error{
   uint64_t time;
 };
 
-typedef struct payment {
+struct payment {
   long id;
   long sender;
   long receiver;
@@ -45,8 +45,7 @@ typedef struct payment {
   int no_balance_count;
   unsigned int is_timeout;
   enum payment_type type;
-
-} payment;
+};
 
 struct payment* new_payment(long sender, long receiver, uint64_t amount, uint64_t start_time, enum payment_type type);
 void init_payment(struct payment* p, long sender, long receiver, uint64_t amount, uint64_t start_time, enum payment_type type);
@@ -55,7 +54,7 @@ int is_expired_payment(const struct payment* payment, uint64_t current_time);
 void set_expired_payment(struct payment* payment, uint64_t current_time);
 
 // Serialization and deserialization functions
-void serialize_payment(payment* payment, char* serialized);
-payment* deserialize_payment(const char* serialized);
+void serialize_payment(struct payment* payment, char* serialized);
+struct payment* deserialize_payment(const char* serialized);
 
 #endif

--- a/src/features/routing.c
+++ b/src/features/routing.c
@@ -257,7 +257,7 @@ double get_edge_weight(uint64_t amount, uint64_t fee, uint32_t timelock){
 }
 
 /* a modified version of dijkstra to find a path connecting the source (payment sender) to the target (payment receiver) */
-struct array* dijkstra(router_state *router_state, long source, long target, long last_hop_id, uint64_t amount, struct network* network, uint64_t current_time, enum pathfind_error *error) {
+struct array* dijkstra(struct router_state *router_state, long source, long target, long last_hop_id, uint64_t amount, struct network* network, uint64_t current_time, enum pathfind_error *error) {
   struct distance *d=NULL, to_node_dist;
   long i, best_node_id, j, from_node_id, curr, shortest_path_target;
   struct node *source_node, *last_hop_node, *target_node, *best_node;

--- a/src/features/routing.c
+++ b/src/features/routing.c
@@ -9,6 +9,7 @@
 #include "routing.h"
 #include "network.h"
 
+#include "../utils/hash_table.h"
 #include "../utils/heap.h"
 #include "../utils/list.h"
 #include "../utils/array.h"

--- a/src/features/routing.h
+++ b/src/features/routing.h
@@ -5,10 +5,11 @@
 #include <pthread.h>
 #include "network.h"
 #include "payments.h"
-#include "../utils/hash_table.h"
 
 #define FINALTIMELOCK 40
 
+
+struct hash_table;
 
 struct distance{
   long node;

--- a/src/features/routing.h
+++ b/src/features/routing.h
@@ -3,13 +3,15 @@
 
 #include <stdint.h>
 #include <pthread.h>
-#include "network.h"
 #include "payments.h"
 
 #define FINALTIMELOCK 40
 
 
 struct hash_table;
+struct node;
+struct network;
+struct element;
 
 struct distance{
   long node;

--- a/src/features/routing.h
+++ b/src/features/routing.h
@@ -5,7 +5,6 @@
 #include <pthread.h>
 #include "network.h"
 #include "payments.h"
-#include "../utils/array.h"
 #include "../utils/hash_table.h"
 
 #define FINALTIMELOCK 40

--- a/src/features/routing.h
+++ b/src/features/routing.h
@@ -56,16 +56,16 @@ enum pathfind_error{
   NOPATH
 };
 
-typedef struct router_state{
+struct router_state{
     int n_find_path;
     struct distance* distance;
     struct heap* distance_heap;
     int rollback_count;
-} router_state;
+};
 
 void get_balance(struct node* node, uint64_t *max_balance, uint64_t *total_balance);
 
-struct array* dijkstra(router_state *router_state, long source, long target, long last_hop_id, uint64_t amount, struct network* network, uint64_t current_time, enum pathfind_error *error);
+struct array* dijkstra(struct router_state *router_state, long source, long target, long last_hop_id, uint64_t amount, struct network* network, uint64_t current_time, enum pathfind_error *error);
 
 void generate_payment_route(struct payment* payment, struct array* path, struct network* network);
 

--- a/src/features/routing.h
+++ b/src/features/routing.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <pthread.h>
-#include "payments.h"
 
 #define FINALTIMELOCK 40
 
@@ -12,6 +11,7 @@ struct hash_table;
 struct node;
 struct network;
 struct element;
+struct payment;
 
 struct distance{
   long node;

--- a/src/features/submarine_swaps.c
+++ b/src/features/submarine_swaps.c
@@ -79,7 +79,7 @@ struct submarine_swap* node_find_swap_by_submarine_payment(struct tw_lp* lp, str
 }
 
 
-void submarine_swaps_on_forward_payment(tw_lp *lp, message *in_msg){
+void submarine_swaps_on_forward_payment(tw_lp *lp, struct message *in_msg){
   // Get the payment
   struct payment* payment = in_msg->payment;
 
@@ -163,19 +163,19 @@ void submarine_swaps_on_forward_payment(tw_lp *lp, message *in_msg){
 
   // Forward the SWAP_REQUEST event
   tw_event *next_e = tw_event_new(prev_node->id, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = SWAP_REQUEST;
   serialize_submarine_swap(swap, next_msg->data);
   tw_event_send(next_e);
 }
 
-void submarine_swaps_on_forward_payment_rev(tw_lp *lp, message *in_msg){
+void submarine_swaps_on_forward_payment_rev(tw_lp *lp, struct message *in_msg){
   // Search for a submarine swap that was started by this forward event
   // Delete if the swap was started
   node_delete_swap(lp, in_msg->swap);
 }
 
-void submarine_swaps_on_swap_request(tw_lp *lp, message *in_msg){
+void submarine_swaps_on_swap_request(tw_lp *lp, struct message *in_msg){
   struct node *node = lp->cur_state;
   submarine_swap* swap = in_msg->swap;
 
@@ -197,13 +197,13 @@ void submarine_swaps_on_swap_request(tw_lp *lp, message *in_msg){
     .originator = node->id
   };
   tw_event *next_e = tw_event_new(blockchain_lp_gid, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = BC_TX_BROADCAST;
   serialize_blockchain_tx(&prepare_htlc_tx, next_msg->data);
   tw_event_send(next_e);
 }
 
-void submarine_swaps_on_swap_request_rev(tw_lp *lp, message *in_msg){
+void submarine_swaps_on_swap_request_rev(tw_lp *lp, struct message *in_msg){
   node_delete_swap(lp, in_msg->swap);
 }
 
@@ -227,7 +227,7 @@ void submarine_swaps_on_blockchain_tx(tw_lp *lp, blockchain_tx* tx){
     struct payment* swap_to_forward = new_payment( swap->submarine_sender, swap->submarine_receiver, swap->amount, tw_now(lp), SUBMARINE_SWAP);
     // Forward the FINDPATH event to the current lp
     tw_event *next_e = tw_event_new(swap_to_forward->sender, 10, lp);
-    message *next_msg = tw_event_data(next_e);
+    struct message *next_msg = tw_event_data(next_e);
     next_msg->type = FINDPATH;
     serialize_payment(swap_to_forward, next_msg->data);
     tw_event_send(next_e);
@@ -290,7 +290,7 @@ void submarine_swaps_on_receive_success(tw_lp *lp, struct payment* payment){
     .originator = node->id
   };
   tw_event *next_e = tw_event_new(blockchain_lp_gid, tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA), lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = BC_TX_BROADCAST;
   serialize_blockchain_tx(&claim_htlc_tx, next_msg->data);
   tw_event_send(next_e);

--- a/src/features/submarine_swaps.c
+++ b/src/features/submarine_swaps.c
@@ -1,5 +1,6 @@
 #include "submarine_swaps.h"
 
+#include "../utils/array.h"
 #include "../model/global.h"
 #include "../model/pcn_node.h"
 #include "../model/blockchain.h"

--- a/src/features/submarine_swaps.c
+++ b/src/features/submarine_swaps.c
@@ -81,7 +81,7 @@ struct submarine_swap* node_find_swap_by_submarine_payment(struct tw_lp* lp, str
 
 void submarine_swaps_on_forward_payment(tw_lp *lp, message *in_msg){
   // Get the payment
-  payment* payment = in_msg->payment;
+  struct payment* payment = in_msg->payment;
 
   /*
    * PrevNode 0 ------- PrevEdge with LOW balance ------> Node 1 ---->
@@ -273,7 +273,7 @@ void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, blockchain_tx* tx){
   }
 }
 
-void submarine_swaps_on_receive_success(tw_lp *lp, payment* payment){
+void submarine_swaps_on_receive_success(tw_lp *lp, struct payment* payment){
   // Return if the blockchain transaction is not related to swaps
   if(payment->type!=SUBMARINE_SWAP) return;
 
@@ -296,7 +296,7 @@ void submarine_swaps_on_receive_success(tw_lp *lp, payment* payment){
   tw_event_send(next_e);
 }
 
-void submarine_swaps_on_receive_success_rev(tw_lp *lp, payment* payment){
+void submarine_swaps_on_receive_success_rev(tw_lp *lp, struct payment* payment){
   // Do nothing, since the only thing we did was generating the claim HTLC
 }
 

--- a/src/features/submarine_swaps.c
+++ b/src/features/submarine_swaps.c
@@ -29,7 +29,7 @@ void node_delete_swap(struct tw_lp* lp, submarine_swap* swap){
   }
 }
 
-struct submarine_swap* node_find_swap_by_blockchain_tx(struct tw_lp* lp, blockchain_tx* tx){
+struct submarine_swap* node_find_swap_by_blockchain_tx(struct tw_lp* lp, struct blockchain_tx* tx){
   struct node* node = lp->cur_state;
   struct submarine_swap* swap = NULL;
   for (int i=0; i<array_len(node->submarine_swaps); i++){
@@ -237,7 +237,7 @@ void submarine_swaps_on_blockchain_tx(tw_lp *lp, blockchain_tx* tx){
   }
 }
 
-void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, blockchain_tx* tx){
+void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, struct blockchain_tx* tx){
   // Return if the blockchain transaction is not related to swaps
   if(tx->type!=PREPARE_HTLC && tx->type!=CLAIM_HTLC) return;
 
@@ -253,7 +253,7 @@ void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, blockchain_tx* tx){
   }
 }
 
-void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, blockchain_tx* tx){
+void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, struct blockchain_tx* tx){
   // Return if the blockchain transaction is not related to swaps
   if(tx->type!=PREPARE_HTLC && tx->type!=CLAIM_HTLC) return;
 

--- a/src/features/submarine_swaps.c
+++ b/src/features/submarine_swaps.c
@@ -2,6 +2,7 @@
 
 #include "../utils/array.h"
 #include "../model/global.h"
+#include "../model/message.h"
 #include "../model/pcn_node.h"
 #include "../model/blockchain.h"
 #include "../utils/logging.h"

--- a/src/features/submarine_swaps.h
+++ b/src/features/submarine_swaps.h
@@ -5,7 +5,9 @@
 #include <ross.h>
 
 #include "payments.h"
-#include "../model/blockchain.h"
+
+struct blockchain_tx;
+struct message;
 
 typedef enum submarine_swap_state {
   REQUESTED,
@@ -29,9 +31,9 @@ void submarine_swaps_on_forward_payment_rev(tw_lp *lp, struct message *in_msg);
 void submarine_swaps_on_swap_request(tw_lp *lp, struct message *in_msg);
 void submarine_swaps_on_swap_request_rev(tw_lp *lp, struct message *in_msg);
 
-void submarine_swaps_on_blockchain_tx(tw_lp *lp, blockchain_tx* tx);
-void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, blockchain_tx* tx);
-void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, blockchain_tx* tx);
+void submarine_swaps_on_blockchain_tx(tw_lp *lp, struct blockchain_tx* tx);
+void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, struct blockchain_tx* tx);
+void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, struct blockchain_tx* tx);
 
 void submarine_swaps_on_receive_success(tw_lp *lp, struct payment* payment);
 void submarine_swaps_on_receive_success_rev(tw_lp *lp, struct payment* payment);

--- a/src/features/submarine_swaps.h
+++ b/src/features/submarine_swaps.h
@@ -4,10 +4,9 @@
 
 #include <ross.h>
 
-#include "payments.h"
-
 struct blockchain_tx;
 struct message;
+struct payment;
 
 typedef enum submarine_swap_state {
   REQUESTED,

--- a/src/features/submarine_swaps.h
+++ b/src/features/submarine_swaps.h
@@ -33,8 +33,8 @@ void submarine_swaps_on_blockchain_tx(tw_lp *lp, blockchain_tx* tx);
 void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, blockchain_tx* tx);
 void submarine_swaps_on_blockchain_tx_commit(tw_lp *lp, blockchain_tx* tx);
 
-void submarine_swaps_on_receive_success(tw_lp *lp, payment* payment);
-void submarine_swaps_on_receive_success_rev(tw_lp *lp, payment* payment);
+void submarine_swaps_on_receive_success(tw_lp *lp, struct payment* payment);
+void submarine_swaps_on_receive_success_rev(tw_lp *lp, struct payment* payment);
 
 // Serialization and deserialization functions
 void serialize_submarine_swap(submarine_swap* tx, char* serialized);

--- a/src/features/submarine_swaps.h
+++ b/src/features/submarine_swaps.h
@@ -23,11 +23,11 @@ typedef struct submarine_swap {
 } submarine_swap;
 
 // Event handling functions
-void submarine_swaps_on_forward_payment(tw_lp *lp, message *in_msg);
-void submarine_swaps_on_forward_payment_rev(tw_lp *lp, message *in_msg);
+void submarine_swaps_on_forward_payment(tw_lp *lp, struct message *in_msg);
+void submarine_swaps_on_forward_payment_rev(tw_lp *lp, struct message *in_msg);
 
-void submarine_swaps_on_swap_request(tw_lp *lp, message *in_msg);
-void submarine_swaps_on_swap_request_rev(tw_lp *lp, message *in_msg);
+void submarine_swaps_on_swap_request(tw_lp *lp, struct message *in_msg);
+void submarine_swaps_on_swap_request_rev(tw_lp *lp, struct message *in_msg);
 
 void submarine_swaps_on_blockchain_tx(tw_lp *lp, blockchain_tx* tx);
 void submarine_swaps_on_blockchain_tx_rev(tw_lp *lp, blockchain_tx* tx);

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "model/pcn_node.h"
 #include "model/load.h"
 #include "model/event_trace.h"
+#include "model/message.h"
 
 #include "utils/array.h"
 #include "utils/heap.h"
@@ -155,7 +156,7 @@ int model_main (int argc, char* argv[]) {
   //set up LPs within ROSS
   nlp_user_per_pe = list_len(array_get(network->partitions, g_tw_mynode));
 	int num_lps_per_pe = g_tw_mynode != 0 ? nlp_user_per_pe : nlp_user_per_pe + 1; // node0 gets the blockchain LP
-	tw_define_lps(num_lps_per_pe, sizeof(message));
+	tw_define_lps(num_lps_per_pe, sizeof(struct message));
 	// note that g_tw_nlp gets set here by tw_define_lps
 
   // IF there are multiple LP types

--- a/src/main.c
+++ b/src/main.c
@@ -160,10 +160,6 @@ int model_main (int argc, char* argv[]) {
 	tw_define_lps(num_lps_per_pe, sizeof(struct message));
 	// note that g_tw_nlp gets set here by tw_define_lps
 
-  // IF there are multiple LP types
-  //    you should define the mapping of GID -> lptype index
-  //g_tw_lp_typemap = &model_typemap;
-
   // set the global variable and initialize each LP's type
   //g_tw_lp_types = model_lps;
   //tw_lp_setup_types();

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "model/load.h"
 #include "model/event_trace.h"
 
+#include "utils/array.h"
 #include "utils/heap.h"
 #include "utils/list.h"
 #include "utils/utils.h"

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ tw_lptype model_lps[] = {
     (commit_f) model_commit,
     (final_f) model_final,
     (map_f) metis_map,
-    sizeof(node*)
+    sizeof(struct node*)
   },
   {
     (init_f) blockchain_init,

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 // - a main function
 
 //includes
+#include "features/network.h"
 #include "features/routing.h"
 
 #include "model/blockchain.h"

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,8 @@
 // - a main function
 
 //includes
+#include "features/routing.h"
+
 #include "model/blockchain.h"
 #include "model/global.h"
 #include "model/pcn_node.h"

--- a/src/model/blockchain.h
+++ b/src/model/blockchain.h
@@ -2,7 +2,8 @@
 #define _blockchain_h
 
 #include <ross.h>
-#include "message.h"
+
+struct message;
 
 typedef enum blockchain_tx_type {
   PREPARE_HTLC,
@@ -25,9 +26,9 @@ typedef struct blockchain {
 
 // Event functions
 void blockchain_init(blockchain *s, tw_lp *lp);
-void blockchain_forward(blockchain *s, tw_bf *bf, message *in_msg, tw_lp *lp);
-void blockchain_reverse(blockchain *s, tw_bf *bf, message *in_msg, tw_lp *lp);
-void blockchain_commit(blockchain *s, tw_bf *bf, message *in_msg, tw_lp *lp);
+void blockchain_forward(blockchain *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void blockchain_reverse(blockchain *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void blockchain_commit(blockchain *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
 void blockchain_final(blockchain *s, tw_lp *lp);
 
 // Serialization and deserialization functions

--- a/src/model/event_trace.c
+++ b/src/model/event_trace.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "event_trace.h"
 
-void event_trace(message *m, tw_lp *lp, char *buffer, int *collect_flag)
+void event_trace(struct message *m, tw_lp *lp, char *buffer, int *collect_flag)
 {
   char event_name[128] = "\0";
   const char* result = getEventName(m->type);

--- a/src/model/event_trace.c
+++ b/src/model/event_trace.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include "event_trace.h"
 
+#include "message.h"
+
 void event_trace(struct message *m, tw_lp *lp, char *buffer, int *collect_flag)
 {
   char event_name[128] = "\0";

--- a/src/model/event_trace.h
+++ b/src/model/event_trace.h
@@ -2,9 +2,10 @@
 #define _event_trace_h
 
 #include <ross.h>
-#include "message.h"
 
 extern st_model_types model_types[];
+
+struct message;
 
 typedef struct event_model_data {
     char event_name[128];

--- a/src/model/event_trace.h
+++ b/src/model/event_trace.h
@@ -11,6 +11,6 @@ typedef struct event_model_data {
     double computation_time;
 } event_model_data;
 
-void event_trace(message *m, tw_lp *lp, char *buffer, int *collect_flag);
+void event_trace(struct message *m, tw_lp *lp, char *buffer, int *collect_flag);
 
 #endif

--- a/src/model/load.c
+++ b/src/model/load.c
@@ -428,7 +428,7 @@ void schedule_next_generate_payment(tw_lp *lp,
 }
 
 // Generate random payment
-void generate_next_random_payment(node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
+void generate_next_random_payment(struct node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   if (in_msg->type != GENERATE_PAYMENT){
     printf("Tx generator of physical entity %ld received event with type != GENERATE_PAYMENT\n", lp->pe->id);
     exit(-1);

--- a/src/model/load.c
+++ b/src/model/load.c
@@ -2,6 +2,7 @@
 #include <limits.h>
 
 #include "load.h"
+#include "message.h"
 #include "global.h"
 
 #include "../utils/logging.h"

--- a/src/model/load.c
+++ b/src/model/load.c
@@ -6,6 +6,7 @@
 #include "global.h"
 
 #include "../features/network.h"
+#include "../features/payments.h"
 
 #include "../utils/logging.h"
 #include "../utils/array.h"

--- a/src/model/load.c
+++ b/src/model/load.c
@@ -5,6 +5,8 @@
 #include "message.h"
 #include "global.h"
 
+#include "../features/network.h"
+
 #include "../utils/logging.h"
 #include "../utils/array.h"
 #include "../utils/utils.h"

--- a/src/model/load.c
+++ b/src/model/load.c
@@ -421,14 +421,14 @@ void schedule_next_generate_payment(tw_lp *lp,
   tw_stime event_offset_ms = fmax(routing_latency + pmt_delay + 1, next_payment_event_ms);
 
   tw_event *next_generate_event = tw_event_new(lp->gid, event_offset_ms, lp);
-  message *next_generate_msg = tw_event_data(next_generate_event);
+  struct message *next_generate_msg = tw_event_data(next_generate_event);
   next_generate_msg->type = GENERATE_PAYMENT;
   memset(&next_generate_msg->data[0], 0, sizeof(next_generate_msg->data));
   tw_event_send(next_generate_event);
 }
 
 // Generate random payment
-void generate_next_random_payment(node *sender, tw_bf *bf, message *in_msg, tw_lp *lp) {
+void generate_next_random_payment(node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   if (in_msg->type != GENERATE_PAYMENT){
     printf("Tx generator of physical entity %ld received event with type != GENERATE_PAYMENT\n", lp->pe->id);
     exit(-1);
@@ -442,7 +442,7 @@ void generate_next_random_payment(node *sender, tw_bf *bf, message *in_msg, tw_l
     memset(&in_msg->data[0], 0, sizeof(in_msg->data));
     tw_stime event_offset = tw_rand_integer(lp->rng, 1, RETRY_GENERATE_RANDOM_MAX_OFFSET);
     tw_event *next_generate_event = tw_event_new(lp->gid, event_offset, lp);
-    message *next_generate_msg = tw_event_data(next_generate_event);
+    struct message *next_generate_msg = tw_event_data(next_generate_event);
     next_generate_msg->type = GENERATE_PAYMENT;
     tw_event_send(next_generate_event);
     in_msg->rng_count = lp->rng->count - rng_initial_count;
@@ -524,7 +524,7 @@ void generate_next_random_payment(node *sender, tw_bf *bf, message *in_msg, tw_l
   // Select the router and forward the FIND_PATH event
   unsigned int pmt_delay = pmt_to_forward->type==WITHDRAWAL ? tw_rand_gamma(lp->rng, DELAY_GAMMA_DISTR_ALPHA, DELAY_GAMMA_DISTR_BETA) : 10;
   tw_event *next_e = tw_event_new(pmt_to_forward->sender, pmt_delay, lp);
-  message *next_msg = tw_event_data(next_e);
+  struct message *next_msg = tw_event_data(next_e);
   next_msg->type = FINDPATH;
   serialize_payment(pmt_to_forward, next_msg->data);
   tw_event_send(next_e);
@@ -548,7 +548,7 @@ void generate_next_random_payment(node *sender, tw_bf *bf, message *in_msg, tw_l
 }
 
 // Rollback withdrawals if created in generate random payment
-void rollback_withdrawal_if_any(tw_bf *bf, message *in_msg, tw_lp *lp) {
+void rollback_withdrawal_if_any(tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   // Increment the rollback count
   g_pe_tx_generator_state.rollback_count++;
   // If the event was the initial event, or the forward handler didn't generate any payment we do not have to rollback anything

--- a/src/model/load.h
+++ b/src/model/load.h
@@ -1,8 +1,12 @@
 #ifndef CLOTH_ROSS_TX_GENERATION_H
 #define CLOTH_ROSS_TX_GENERATION_H
 
-#include "pcn_node.h"
+#include <ross.h>
+
 #include "../features/payments.h"
+
+struct message;
+struct node;
 
 /*
  * The load shaping algorithm will divide the total simulation time in

--- a/src/model/load.h
+++ b/src/model/load.h
@@ -3,7 +3,6 @@
 
 #include <ross.h>
 
-#include "../features/payments.h"
 
 struct message;
 struct node;

--- a/src/model/load.h
+++ b/src/model/load.h
@@ -24,9 +24,9 @@ struct tx_generator_state {
 
 void schedule_next_generate_payment(tw_lp *lp, unsigned int routing_latency, unsigned int pmt_delay);
 
-void generate_next_random_payment(node *sender, tw_bf *bf, message *in_msg, tw_lp *lp);
+void generate_next_random_payment(node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp);
 
-void rollback_withdrawal_if_any(tw_bf *bf, message *in_msg, tw_lp *lp);
+void rollback_withdrawal_if_any(tw_bf *bf, struct message *in_msg, tw_lp *lp);
 
 void init_node_indexes_per_pe();
 

--- a/src/model/load.h
+++ b/src/model/load.h
@@ -24,7 +24,7 @@ struct tx_generator_state {
 
 void schedule_next_generate_payment(tw_lp *lp, unsigned int routing_latency, unsigned int pmt_delay);
 
-void generate_next_random_payment(node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void generate_next_random_payment(struct node *sender, tw_bf *bf, struct message *in_msg, tw_lp *lp);
 
 void rollback_withdrawal_if_any(tw_bf *bf, struct message *in_msg, tw_lp *lp);
 

--- a/src/model/mapping.c
+++ b/src/model/mapping.c
@@ -10,6 +10,9 @@
 #include "global.h"
 #include "pcn_node.h"
 #include "event_trace.h"
+
+#include "../features/network.h"
+
 #include "../utils/array.h"
 #include "../utils/list.h"
 

--- a/src/model/message.h
+++ b/src/model/message.h
@@ -33,7 +33,7 @@ typedef enum event_type {
 //   this contains all data sent in an event
 #define MAX_SERIALIZED_LENGTH 1024
 
-typedef struct {
+struct message {
   // Message type and serialized data
   event_type type;
   char data[MAX_SERIALIZED_LENGTH];
@@ -47,7 +47,7 @@ typedef struct {
   unsigned long rng_count;
   tw_stime fwd_handler_time;
   double computation_time;
-} message;
+};
 
 const char* getEventName(event_type event);
 

--- a/src/model/pcn_node.c
+++ b/src/model/pcn_node.c
@@ -19,6 +19,7 @@
 #include "../features/htlc.h"
 #include "../features/routing.h"
 
+#include "../utils/array.h"
 #include "../utils/logging.h"
 #include "../utils/utils.h"
 

--- a/src/model/pcn_node.c
+++ b/src/model/pcn_node.c
@@ -26,7 +26,7 @@
 //Init function
 // - called once for each LP
 // ! LP can only send messages to itself during init !
-void model_init (node *s, tw_lp *lp) {
+void model_init (struct node *s, tw_lp *lp) {
   // init state data
   s = array_get(network->nodes, lp->gid);
   lp->cur_state = s;
@@ -39,7 +39,7 @@ void model_init (node *s, tw_lp *lp) {
 }
 
 // (USER) Forward event handler
-void model_event (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
+void model_event (struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   tw_clock start_time = tw_clock_read();
   // Init message fields that contain results of deserialization
   in_msg->payment = NULL;
@@ -149,7 +149,7 @@ void model_event (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
 }
 
 //Reverse Event Handler
-void model_event_reverse (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
+void model_event_reverse (struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   debug_node_reverse(node_out_file, bf, lp, in_msg);
 
   // undo the state update using the value stored in the 'reverse' message
@@ -227,7 +227,7 @@ void model_event_reverse (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp)
 }
 
 // (USER) Commit event handler
-void model_commit (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
+void model_commit (struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   debug_node_commit(node_out_file, lp, in_msg);
 
   switch (in_msg->type) {
@@ -279,7 +279,7 @@ void model_commit (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
 
 //report any final statistics for this LP
 int pe_header_written=0;
-void model_final (node *s, tw_lp *lp){
+void model_final (struct node *s, tw_lp *lp){
   struct element *iterator;
   if(!pe_header_written++) {
     // Check for payments awaiting expired withdrawals

--- a/src/model/pcn_node.c
+++ b/src/model/pcn_node.c
@@ -10,6 +10,7 @@
 
 #include "global.h"
 #include "load.h"
+#include "message.h"
 #include "pcn_node.h"
 #include "blockchain.h"
 

--- a/src/model/pcn_node.c
+++ b/src/model/pcn_node.c
@@ -18,6 +18,7 @@
 #include "../features/submarine_swaps.h"
 #include "../features/routing.h"
 #include "../features/htlc.h"
+#include "../features/network.h"
 #include "../features/routing.h"
 
 #include "../utils/array.h"

--- a/src/model/pcn_node.c
+++ b/src/model/pcn_node.c
@@ -39,7 +39,7 @@ void model_init (node *s, tw_lp *lp) {
 }
 
 // (USER) Forward event handler
-void model_event (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
+void model_event (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   tw_clock start_time = tw_clock_read();
   // Init message fields that contain results of deserialization
   in_msg->payment = NULL;
@@ -68,7 +68,7 @@ void model_event (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
       if (path != NULL){
         // Here we would like to simulate the time required to run a findpath on the sender device
         tw_event *next_e = tw_event_new(in_msg->payment->sender, ROUTING_LATENCY, lp);
-        message *next_msg = tw_event_data(next_e);
+        struct message *next_msg = tw_event_data(next_e);
         generate_payment_route(in_msg->payment, path, network);
         array_free(path);
         next_msg->type = SENDPAYMENT;
@@ -149,7 +149,7 @@ void model_event (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
 }
 
 //Reverse Event Handler
-void model_event_reverse (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
+void model_event_reverse (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   debug_node_reverse(node_out_file, bf, lp, in_msg);
 
   // undo the state update using the value stored in the 'reverse' message
@@ -227,7 +227,7 @@ void model_event_reverse (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
 }
 
 // (USER) Commit event handler
-void model_commit (node *s, tw_bf *bf, message *in_msg, tw_lp *lp) {
+void model_commit (node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp) {
   debug_node_commit(node_out_file, lp, in_msg);
 
   switch (in_msg->type) {

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -26,9 +26,9 @@ extern tw_lptype model_lps[];
 // defined in model_driver.c:
 // LP - Users
 extern void model_init(node *s, tw_lp *lp);
-extern void model_event(node *s, tw_bf *bf, message *in_msg, tw_lp *lp);
-extern void model_commit(node *s, tw_bf *bf, message *in_msg, tw_lp *lp);
-extern void model_event_reverse(node *s, tw_bf *bf, message *in_msg, tw_lp *lp);
+extern void model_event(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+extern void model_commit(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+extern void model_event_reverse(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
 extern void model_final(node *s, tw_lp *lp);
 
 // defined in model_map.c:

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -20,13 +20,13 @@ struct node;
 extern tw_lptype model_lps[];
 
 //Function Declarations
-// defined in model_driver.c:
+// defined in pcn_node.c:
 // LP - Users
-extern void model_init(struct node *s, tw_lp *lp);
-extern void model_event(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_commit(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_event_reverse(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_final(struct node *s, tw_lp *lp);
+void model_init(struct node *s, tw_lp *lp);
+void model_event(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void model_commit(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void model_event_reverse(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+void model_final(struct node *s, tw_lp *lp);
 
 
 //Custom mapping prototypes

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -1,7 +1,6 @@
 //The header file template for a ROSS model
 //This file includes:
 // - the state and message structs
-// - extern'ed command line arguments
 // - custom mapping function prototypes (if needed)
 // - any other needed structs, enums, unions, or #defines
 
@@ -15,9 +14,6 @@
 
 struct message;
 struct node;
-
-//Command Line Argument declarations
-extern unsigned int setting_1;
 
 //Global variables used by both main and driver
 // - this defines the LP types

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -10,10 +10,11 @@
 
 #include <ross.h>
 
-#include "message.h"
 #include "../features/network.h"
 
 #define INF UINT64_MAX
+
+struct message;
 
 //Command Line Argument declarations
 extern unsigned int setting_1;

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -28,20 +28,10 @@ extern void model_commit(struct node *s, tw_bf *bf, struct message *in_msg, tw_l
 extern void model_event_reverse(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
 extern void model_final(struct node *s, tw_lp *lp);
 
-// defined in model_map.c:
-extern tw_peid model_map(tw_lpid gid);
-
 
 //Custom mapping prototypes
-void model_custom_mapping(void);
-tw_lp * model_mapping_to_lp(tw_lpid lpid);
-tw_peid model_map(tw_lpid gid);
-
-//Custom mapping prototypes
-//tw_lpid metis_typemap (tw_lpid gid);
 void metis_custom_mapping(void);
 tw_lp * metis_mapping_to_lp(tw_lpid lpid);
 tw_peid metis_map(tw_lpid gid);
 
-tw_lpid model_typemap (tw_lpid gid);
 #endif

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -25,11 +25,11 @@ extern tw_lptype model_lps[];
 //Function Declarations
 // defined in model_driver.c:
 // LP - Users
-extern void model_init(node *s, tw_lp *lp);
-extern void model_event(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_commit(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_event_reverse(node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
-extern void model_final(node *s, tw_lp *lp);
+extern void model_init(struct node *s, tw_lp *lp);
+extern void model_event(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+extern void model_commit(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+extern void model_event_reverse(struct node *s, tw_bf *bf, struct message *in_msg, tw_lp *lp);
+extern void model_final(struct node *s, tw_lp *lp);
 
 // defined in model_map.c:
 extern tw_peid model_map(tw_lpid gid);

--- a/src/model/pcn_node.h
+++ b/src/model/pcn_node.h
@@ -10,11 +10,11 @@
 
 #include <ross.h>
 
-#include "../features/network.h"
 
 #define INF UINT64_MAX
 
 struct message;
+struct node;
 
 //Command Line Argument declarations
 extern unsigned int setting_1;

--- a/src/utils/logging.c
+++ b/src/utils/logging.c
@@ -1,5 +1,7 @@
 #include "logging.h"
 
+#include "../features/payments.h"
+
 // Enable tracing
 int g_dbg_trace=0;
 
@@ -11,7 +13,7 @@ void debug_msg(message* msg, char* out){
   snprintf(out, DEBUG_BUF_SIZE, "%s", getEventName(msg->type));
 }
 
-void debug_payment(payment* payment, char* out){
+void debug_payment(struct payment* payment, char* out){
   snprintf(out, DEBUG_BUF_SIZE, "pmt.id %12ld", payment->id);
 }
 

--- a/src/utils/logging.c
+++ b/src/utils/logging.c
@@ -1,6 +1,7 @@
 #include "logging.h"
 
 #include "../features/payments.h"
+#include "../features/submarine_swaps.h"
 #include "../model/message.h"
 
 // Enable tracing

--- a/src/utils/logging.c
+++ b/src/utils/logging.c
@@ -1,5 +1,6 @@
 #include "logging.h"
 
+#include "../model/blockchain.h"
 #include "../features/payments.h"
 #include "../features/submarine_swaps.h"
 #include "../model/message.h"

--- a/src/utils/logging.c
+++ b/src/utils/logging.c
@@ -1,6 +1,7 @@
 #include "logging.h"
 
 #include "../features/payments.h"
+#include "../model/message.h"
 
 // Enable tracing
 int g_dbg_trace=0;
@@ -9,7 +10,7 @@ void debug_lp(char lp_name[5], tw_lp* lp, char* out){
   snprintf(out, DEBUG_BUF_SIZE, "%s #%7lu @%2.3f", lp_name, lp->gid, tw_now(lp));
 }
 
-void debug_msg(message* msg, char* out){
+void debug_msg(struct message* msg, char* out){
   snprintf(out, DEBUG_BUF_SIZE, "%s", getEventName(msg->type));
 }
 
@@ -27,7 +28,7 @@ void debug_blockchain_tx(struct blockchain_tx* tx, char* out){
     getTxType(tx->type), tx->originator, tx->sender, tx->receiver, tx->amount, tx->start_time);
 }
 
-void debug_node_forward(FILE* node_out_file, tw_lp* lp, message* msg){
+void debug_node_forward(FILE* node_out_file, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -60,7 +61,7 @@ void debug_node_forward(FILE* node_out_file, tw_lp* lp, message* msg){
   }
 }
 
-void debug_node_commit(FILE* node_out_file, tw_lp* lp, message* msg){
+void debug_node_commit(FILE* node_out_file, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -93,7 +94,7 @@ void debug_node_commit(FILE* node_out_file, tw_lp* lp, message* msg){
   }
 }
 
-void debug_node_reverse(FILE* node_out_file, tw_bf *bf, tw_lp* lp, message* msg){
+void debug_node_reverse(FILE* node_out_file, tw_bf *bf, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -126,7 +127,7 @@ void debug_node_reverse(FILE* node_out_file, tw_bf *bf, tw_lp* lp, message* msg)
   }
 }
 
-void debug_node_generate_forward(FILE* node_out_file, tw_lp* lp, message* msg, long payment_id){
+void debug_node_generate_forward(FILE* node_out_file, tw_lp* lp, struct message* msg, long payment_id){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -137,7 +138,7 @@ void debug_node_generate_forward(FILE* node_out_file, tw_lp* lp, message* msg, l
   }
 }
 
-void debug_node_generate_reverse(FILE* node_out_file, tw_lp* lp, message* msg, long payment_id){
+void debug_node_generate_reverse(FILE* node_out_file, tw_lp* lp, struct message* msg, long payment_id){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -148,7 +149,7 @@ void debug_node_generate_reverse(FILE* node_out_file, tw_lp* lp, message* msg, l
   }
 }
 
-void debug_blockchain_forward(FILE* node_out_file, tw_lp* lp, message* msg){
+void debug_blockchain_forward(FILE* node_out_file, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -168,7 +169,7 @@ void debug_blockchain_forward(FILE* node_out_file, tw_lp* lp, message* msg){
   }
 }
 
-void debug_blockchain_reverse(FILE* node_out_file, tw_lp* lp, message* msg){
+void debug_blockchain_reverse(FILE* node_out_file, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];
@@ -188,7 +189,7 @@ void debug_blockchain_reverse(FILE* node_out_file, tw_lp* lp, message* msg){
   }
 }
 
-void debug_blockchain_commit(FILE* node_out_file, tw_lp* lp, message* msg){
+void debug_blockchain_commit(FILE* node_out_file, tw_lp* lp, struct message* msg){
   if (g_dbg_trace){
     char lpstr[DEBUG_BUF_SIZE];
     char msgstr[DEBUG_BUF_SIZE];

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -3,25 +3,24 @@
 
 #include "../features/submarine_swaps.h"
 #include "../model/blockchain.h"
-#include "../model/message.h"
 
 #define DEBUG_BUF_SIZE 500
 
 void debug_lp(char lp_name[5], tw_lp* lp, char* out);
-void debug_msg(message* msg, char* out);
+void debug_msg(struct message* msg, char* out);
 void debug_payment(struct payment* payment, char* out);
 void debug_submarine_swap(struct submarine_swap* swap, char* out);
 void debug_blockchain_tx(struct blockchain_tx* tx, char* out);
 
-void debug_node_forward(FILE* node_out_file, tw_lp* lp, message* msg);
-void debug_node_reverse(FILE* node_out_file, tw_bf *bf, tw_lp* lp, message* msg);
-void debug_node_commit(FILE* node_out_file, tw_lp* lp, message* msg);
+void debug_node_forward(FILE* node_out_file, tw_lp* lp, struct message* msg);
+void debug_node_reverse(FILE* node_out_file, tw_bf *bf, tw_lp* lp, struct message* msg);
+void debug_node_commit(FILE* node_out_file, tw_lp* lp, struct message* msg);
 
-void debug_node_generate_forward(FILE* node_out_file, tw_lp* lp, message* msg, long payment_id);
-void debug_node_generate_reverse(FILE* node_out_file, tw_lp* lp, message* msg, long payment_id);
+void debug_node_generate_forward(FILE* node_out_file, tw_lp* lp, struct message* msg, long payment_id);
+void debug_node_generate_reverse(FILE* node_out_file, tw_lp* lp, struct message* msg, long payment_id);
 
-void debug_blockchain_forward(FILE* node_out_file, tw_lp* lp, message* msg);
-void debug_blockchain_reverse(FILE* node_out_file, tw_lp* lp, message* msg);
-void debug_blockchain_commit(FILE* node_out_file, tw_lp* lp, message* msg);
+void debug_blockchain_forward(FILE* node_out_file, tw_lp* lp, struct message* msg);
+void debug_blockchain_reverse(FILE* node_out_file, tw_lp* lp, struct message* msg);
+void debug_blockchain_commit(FILE* node_out_file, tw_lp* lp, struct message* msg);
 
 #endif

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -1,10 +1,12 @@
 #ifndef _logging_h
 #define _logging_h
 
-#include "../model/blockchain.h"
+#include <ross.h>
 
 #define DEBUG_BUF_SIZE 500
 
+struct blockchain_tx;
+struct message;
 struct payment;
 struct submarine_swap;
 

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -1,10 +1,12 @@
 #ifndef _logging_h
 #define _logging_h
 
-#include "../features/submarine_swaps.h"
 #include "../model/blockchain.h"
 
 #define DEBUG_BUF_SIZE 500
+
+struct payment;
+struct submarine_swap;
 
 void debug_lp(char lp_name[5], tw_lp* lp, char* out);
 void debug_msg(struct message* msg, char* out);

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -1,7 +1,6 @@
 #ifndef _logging_h
 #define _logging_h
 
-#include "../features/payments.h"
 #include "../features/submarine_swaps.h"
 #include "../model/blockchain.h"
 #include "../model/message.h"

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include "heap.h"
 #include "../features/htlc.h"
+#include "../features/payments.h"
 #include "../features/routing.h"
 #include "../model/global.h"
 

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include "heap.h"
 #include "../features/htlc.h"
+#include "../features/network.h"
 #include "../features/payments.h"
 #include "../features/routing.h"
 #include "../model/global.h"

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -6,6 +6,7 @@
 #include "array.h"
 #include "utils.h"
 #include "heap.h"
+#include "../features/htlc.h"
 #include "../features/routing.h"
 #include "../model/global.h"
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,8 +2,9 @@
 #define UTILS_H
 #include <stdbool.h>
 
-#include "../features/htlc.h"
 #include "../features/routing.h"
+
+struct node_pair_result;
 
 int is_equal_result(struct node_pair_result *a, struct node_pair_result *b);
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,9 +2,11 @@
 #define UTILS_H
 #include <stdbool.h>
 
-#include "../features/routing.h"
-
 struct node_pair_result;
+struct node_list_element;
+struct distance;
+struct network;
+struct network_params;
 
 int is_equal_result(struct node_pair_result *a, struct node_pair_result *b);
 


### PR DESCRIPTION
This PR streamlines the dependencies of the simulator: before the change, almost every file depended on each other because of a small number of global headers.

Let's loosen up the dependencies moving the inclusion in the `.c` files, and using forward declarations in the headers. The PR also tries to uniform the declaration style for our structs, removing `typedef struct`: the majority of our code used that idiom, and it's advisable to stick to a single convention.
